### PR TITLE
Add c128 support, tweak makefile

### DIFF
--- a/float-c128.inc
+++ b/float-c128.inc
@@ -20,8 +20,9 @@ FAC_ROUNDING     = $70
 ; the following are the addresses in the C64 ROM - the library can probably be
 ; used with other CBM targets just by adjusting these addresses
 
-; Mapping the C128 p224
-BASIC_FAC_Not       = $aed4     ; in/out: FAC
+; Mapping the C128 p224 / Programmers 522 (but the jump table
+; value at the given location)
+BASIC_FAC_Not       = $8ffa     ; in/out: FAC updated (negates sign routine, but NOT appears to be two's complement in BASIC)
 BASIC_FAC_Cos       = $9409     ; in/out: FAC updated
 BASIC_FAC_Sin       = $9410     ; in/out: FAC updated
 BASIC_FAC_Tan       = $9459     ; in/out: FAC updated
@@ -37,11 +38,11 @@ BASIC_FAC_Abs       = $8c84     ; in/out: FAC updated
 
 BASIC_ARG_FAC_Or    = $afe6     ; in: ARG,FAC out:FAC
 BASIC_ARG_FAC_And   = $afe9     ; in: ARG,FAC out:FAC
-BASIC_ARG_FAC_Sub   = $b853     ; in: ARG,FAC out:FAC
-BASIC_ARG_FAC_Add   = $b86a     ; in: ARG,FAC out:FAC
-BASIC_ARG_FAC_Mul   = $ba2b     ; in: ARG,FAC out:FAC
-BASIC_ARG_FAC_Div   = $bb12     ; in: ARG,FAC out:FAC
-BASIC_ARG_FAC_Pow   = $bf7b     ; in: ARG,FAC out:FAC
+BASIC_ARG_FAC_Sub   = $8831     ; in: ARG,FAC out:FAC updated
+BASIC_ARG_FAC_Add   = $8848     ; in: ARG,FAC out:FAC updated
+BASIC_ARG_FAC_Mul   = $8a27     ; in: ARG,FAC out:FAC updated
+BASIC_ARG_FAC_Div   = $8b4c     ; in: ARG,FAC out:FAC updated
+BASIC_ARG_FAC_Pow   = $8fc1     ; in: ARG,FAC out:FAC updated
 
 BASIC_u8_to_FAC     = $b3a2     ; y: value
 BASIC_s8_to_FAC     = $bc3c     ; a: value

--- a/float-c128.inc
+++ b/float-c128.inc
@@ -23,16 +23,16 @@ FAC_ROUNDING     = $70
 ; Mapping the C128 p224 / Programmers 522 (but the jump table
 ; value at the given location)
 BASIC_FAC_Not       = $8ffa     ; in/out: FAC updated (negates sign routine, but NOT appears to be two's complement in BASIC)
-BASIC_FAC_Cos       = $9409     ; in/out: FAC updated
-BASIC_FAC_Sin       = $9410     ; in/out: FAC updated
-BASIC_FAC_Tan       = $9459     ; in/out: FAC updated
-BASIC_FAC_Atn       = $94b3     ; in/out: FAC updated
-BASIC_FAC_Rnd       = $8434     ; in/out: FAC updated
-BASIC_FAC_Int       = $8cfb     ; in/out: FAC updated
-BASIC_FAC_Sqr       = $8fb7     ; in/out: FAC updated
-BASIC_FAC_Exp       = $9033     ; in/out: FAC updated
-BASIC_FAC_Log       = $89ca     ; in/out: FAC updated
-BASIC_FAC_Round     = $8c47     ; in/out: FAC updated
+BASIC_FAC_Cos       = $9409     ; in/out: FAC updated (p 227)
+BASIC_FAC_Sin       = $9410     ; in/out: FAC updated (p 227)
+BASIC_FAC_Tan       = $9459     ; in/out: FAC updated (p 227)
+BASIC_FAC_Atn       = $94b3     ; in/out: FAC updated (p 227)
+BASIC_FAC_Rnd       = $8434     ; in/out: FAC updated (p 220)
+BASIC_FAC_Int       = $8cfb     ; in/out: FAC updated (p 224)
+BASIC_FAC_Sqr       = $8fb7     ; in/out: FAC updated (p 225)
+BASIC_FAC_Exp       = $9033     ; in/out: FAC updated (p 225)
+BASIC_FAC_Log       = $89ca     ; in/out: FAC updated (p 223)
+BASIC_FAC_Round     = $8c47     ; in/out: FAC updated (p 224)
 BASIC_FAC_Sgn       = $8c65     ; in/out: FAC updated
 BASIC_FAC_Abs       = $8c84     ; in/out: FAC updated
 

--- a/float-c128.inc
+++ b/float-c128.inc
@@ -20,14 +20,15 @@ FAC_ROUNDING     = $70
 ; the following are the addresses in the C64 ROM - the library can probably be
 ; used with other CBM targets just by adjusting these addresses
 
+; Mapping the C128 p224
 BASIC_FAC_Not       = $aed4     ; in/out: FAC
-BASIC_FAC_Cos       = $af3f     ; in/out: FAC
-BASIC_FAC_Sin       = $af42     ; in/out: FAC
-BASIC_FAC_Tan       = $af45     ; in/out: FAC
-BASIC_FAC_Atn       = $af48     ; in/out: FAC
+BASIC_FAC_Cos       = $9409     ; in/out: FAC
+BASIC_FAC_Sin       = $9410     ; in/out: FAC
+BASIC_FAC_Tan       = $9459     ; in/out: FAC
+BASIC_FAC_Atn       = $94b3     ; in/out: FAC
 BASIC_FAC_Rnd       = $e097     ; in/out: FAC
 BASIC_FAC_Int       = $af00     ; in/out: FAC
-BASIC_FAC_Sqr       = $bf71     ; in/out: FAC
+BASIC_FAC_Sqr       = $2fb7     ; in/out: FAC
 BASIC_FAC_Exp       = $af3c     ; in/out: FAC
 BASIC_FAC_Log       = $b9ea     ; in/out: FAC
 BASIC_FAC_Round     = $af4b     ; in/out: FAC

--- a/float-c128.inc
+++ b/float-c128.inc
@@ -1,0 +1,63 @@
+FAC_EXPONENT    = $61
+FAC_MANTISSA0   = $62
+FAC_MANTISSA1   = $63
+FAC_MANTISSA2   = $64
+FAC_MANTISSA3   = $65
+FAC_SIGN        = $66
+
+ARG_EXPONENT    = $69
+ARG_MANTISSA0   = $6a
+ARG_MANTISSA1   = $6b
+ARG_MANTISSA2   = $6c
+ARG_MANTISSA3   = $6d
+ARG_SIGN        = $6e
+
+FAC_SIGN_COMPARE = $6f
+FAC_ROUNDING     = $70
+
+; addresses of the floating point routines in CBM BASIC V7
+
+; the following are the addresses in the C64 ROM - the library can probably be
+; used with other CBM targets just by adjusting these addresses
+
+BASIC_FAC_Not       = $aed4     ; in/out: FAC
+BASIC_FAC_Cos       = $af3f     ; in/out: FAC
+BASIC_FAC_Sin       = $af42     ; in/out: FAC
+BASIC_FAC_Tan       = $af45     ; in/out: FAC
+BASIC_FAC_Atn       = $af48     ; in/out: FAC
+BASIC_FAC_Rnd       = $e097     ; in/out: FAC
+BASIC_FAC_Int       = $af00     ; in/out: FAC
+BASIC_FAC_Sqr       = $bf71     ; in/out: FAC
+BASIC_FAC_Exp       = $af3c     ; in/out: FAC
+BASIC_FAC_Log       = $b9ea     ; in/out: FAC
+BASIC_FAC_Round     = $af4b     ; in/out: FAC
+BASIC_FAC_Sgn       = $af51     ; in/out: FAC
+BASIC_FAC_Abs       = $bc58     ; in/out: FAC
+
+BASIC_ARG_FAC_Or    = $afe6     ; in: ARG,FAC out:FAC
+BASIC_ARG_FAC_And   = $afe9     ; in: ARG,FAC out:FAC
+BASIC_ARG_FAC_Sub   = $b853     ; in: ARG,FAC out:FAC
+BASIC_ARG_FAC_Add   = $b86a     ; in: ARG,FAC out:FAC
+BASIC_ARG_FAC_Mul   = $ba2b     ; in: ARG,FAC out:FAC
+BASIC_ARG_FAC_Div   = $bb12     ; in: ARG,FAC out:FAC
+BASIC_ARG_FAC_Pow   = $bf7b     ; in: ARG,FAC out:FAC
+
+BASIC_u8_to_FAC     = $b3a2     ; y: value
+BASIC_s8_to_FAC     = $bc3c     ; a: value
+BASIC_u16_to_FAC    = $bc49     ; a/y:lo/hi value (sta $62 sty $63 sec ldx#$90 jsr...)
+BASIC_s16_to_FAC    = $b395     ; a/y:lo/hi value
+
+BASIC_FAC_to_u16    = $bc9b     ; in:FAC out: y/a:lo/hi value
+
+BASIC_string_to_FAC = $b7b5     ; in: $22/$23 ptr to str,a=strlen out: FAC value
+BASIC_FAC_to_string = $bddd     ; in: FAC value   out: str at $0100 a/y ptr to str
+
+BASIC_LoadARG       = $ba8c     ; a/y:lo/hi ptr to 5-byte float
+BASIC_LoadFAC       = $bba2     ; a/y:lo/hi ptr to 5-byte float
+
+BASIC_FAC_testsgn   = $bc2b     ; in: FAC(x1) out: a=0 (x1=0) a=1 (x1>0) a=255 (x1<0)
+BASIC_FAC_cmp       = $bc5b     ; in: FAC(x1) a/y ptr lo/hi to x2 out: a=0 (x1=x2) a=1 (x1>x2) a=255 (x1<x2)
+
+BASIC_FAC_Poly2     = $e043     ; in: FAC x  a/y ptr to poly (1byte grade,5bytes per coefficient)
+BASIC_FAC_Poly1     = $e059     ; in: FAC x  a/y ptr to poly (1byte grade,5bytes per coefficient)
+

--- a/float-c128.inc
+++ b/float-c128.inc
@@ -22,16 +22,16 @@ FAC_ROUNDING     = $70
 
 ; Mapping the C128 p224
 BASIC_FAC_Not       = $aed4     ; in/out: FAC
-BASIC_FAC_Cos       = $9409     ; in/out: FAC
-BASIC_FAC_Sin       = $9410     ; in/out: FAC
-BASIC_FAC_Tan       = $9459     ; in/out: FAC
-BASIC_FAC_Atn       = $94b3     ; in/out: FAC
-BASIC_FAC_Rnd       = $e097     ; in/out: FAC
-BASIC_FAC_Int       = $af00     ; in/out: FAC
-BASIC_FAC_Sqr       = $2fb7     ; in/out: FAC
-BASIC_FAC_Exp       = $af3c     ; in/out: FAC
-BASIC_FAC_Log       = $b9ea     ; in/out: FAC
-BASIC_FAC_Round     = $af4b     ; in/out: FAC
+BASIC_FAC_Cos       = $9409     ; in/out: FAC updated
+BASIC_FAC_Sin       = $9410     ; in/out: FAC updated
+BASIC_FAC_Tan       = $9459     ; in/out: FAC updated
+BASIC_FAC_Atn       = $94b3     ; in/out: FAC updated
+BASIC_FAC_Rnd       = $8434     ; in/out: FAC updated
+BASIC_FAC_Int       = $af00     ; in/out: FAC ??
+BASIC_FAC_Sqr       = $8fb7     ; in/out: FAC updated
+BASIC_FAC_Exp       = $9033     ; in/out: FAC updated
+BASIC_FAC_Log       = $89ca     ; in/out: FAC updated
+BASIC_FAC_Round     = $8c47     ; in/out: FAC updated
 BASIC_FAC_Sgn       = $af51     ; in/out: FAC
 BASIC_FAC_Abs       = $bc58     ; in/out: FAC
 

--- a/float-c128.inc
+++ b/float-c128.inc
@@ -27,13 +27,13 @@ BASIC_FAC_Sin       = $9410     ; in/out: FAC updated
 BASIC_FAC_Tan       = $9459     ; in/out: FAC updated
 BASIC_FAC_Atn       = $94b3     ; in/out: FAC updated
 BASIC_FAC_Rnd       = $8434     ; in/out: FAC updated
-BASIC_FAC_Int       = $af00     ; in/out: FAC ??
+BASIC_FAC_Int       = $8cfb     ; in/out: FAC updated
 BASIC_FAC_Sqr       = $8fb7     ; in/out: FAC updated
 BASIC_FAC_Exp       = $9033     ; in/out: FAC updated
 BASIC_FAC_Log       = $89ca     ; in/out: FAC updated
 BASIC_FAC_Round     = $8c47     ; in/out: FAC updated
-BASIC_FAC_Sgn       = $af51     ; in/out: FAC
-BASIC_FAC_Abs       = $bc58     ; in/out: FAC
+BASIC_FAC_Sgn       = $8c65     ; in/out: FAC updated
+BASIC_FAC_Abs       = $8c84     ; in/out: FAC updated
 
 BASIC_ARG_FAC_Or    = $afe6     ; in: ARG,FAC out:FAC
 BASIC_ARG_FAC_And   = $afe9     ; in: ARG,FAC out:FAC

--- a/float-c128.inc
+++ b/float-c128.inc
@@ -1,24 +1,26 @@
-FAC_EXPONENT    = $61
-FAC_MANTISSA0   = $62
-FAC_MANTISSA1   = $63
-FAC_MANTISSA2   = $64
-FAC_MANTISSA3   = $65
-FAC_SIGN        = $66
+; C128 BASIC V7 zero page floating point register locations
+; Note: C128 FAC1 is at $63-$68 (not $61-$66 as on C64/VIC-20)
 
-ARG_EXPONENT    = $69
-ARG_MANTISSA0   = $6a
-ARG_MANTISSA1   = $6b
-ARG_MANTISSA2   = $6c
-ARG_MANTISSA3   = $6d
-ARG_SIGN        = $6e
+FAC_EXPONENT    = $63
+FAC_MANTISSA0   = $64
+FAC_MANTISSA1   = $65
+FAC_MANTISSA2   = $66
+FAC_MANTISSA3   = $67
+FAC_SIGN        = $68
 
-FAC_SIGN_COMPARE = $6f
-FAC_ROUNDING     = $70
+ARG_EXPONENT    = $6a
+ARG_MANTISSA0   = $6b
+ARG_MANTISSA1   = $6c
+ARG_MANTISSA2   = $6d
+ARG_MANTISSA3   = $6e
+ARG_SIGN        = $6f
+
+FAC_SIGN_COMPARE = $70   ; ARISGN
+FAC_ROUNDING     = $71   ; FACOV
 
 ; addresses of the floating point routines in CBM BASIC V7
 
-; the following are the addresses in the C64 ROM - the library can probably be
-; used with other CBM targets just by adjusting these addresses
+; the following are the addresses in the C128 ROM
 
 ; Mapping the C128 p224 / Programmers 522 (but the jump table
 ; value at the given location)
@@ -36,30 +38,32 @@ BASIC_FAC_Round     = $8c47     ; in/out: FAC updated (p 224)
 BASIC_FAC_Sgn       = $8c65     ; in/out: FAC updated
 BASIC_FAC_Abs       = $8c84     ; in/out: FAC updated
 
-BASIC_ARG_FAC_Or    = $afe6     ; in: ARG,FAC out:FAC
-BASIC_ARG_FAC_And   = $afe9     ; in: ARG,FAC out:FAC
+BASIC_ARG_FAC_Or    = $4c86     ; in: ARG,FAC out:FAC (p 209)
+BASIC_ARG_FAC_And   = $4c89     ; in: ARG,FAC out:FAC (p 209)
 BASIC_ARG_FAC_Sub   = $8831     ; in: ARG,FAC out:FAC updated
 BASIC_ARG_FAC_Add   = $8848     ; in: ARG,FAC out:FAC updated
 BASIC_ARG_FAC_Mul   = $8a27     ; in: ARG,FAC out:FAC updated
 BASIC_ARG_FAC_Div   = $8b4c     ; in: ARG,FAC out:FAC updated
 BASIC_ARG_FAC_Pow   = $8fc1     ; in: ARG,FAC out:FAC updated
 
-BASIC_u8_to_FAC     = $b3a2     ; y: value
-BASIC_s8_to_FAC     = $bc3c     ; a: value
-BASIC_u16_to_FAC    = $bc49     ; a/y:lo/hi value (sta $62 sty $63 sec ldx#$90 jsr...)
-BASIC_s16_to_FAC    = $b395     ; a/y:lo/hi value
+; GIVAYF: Y=lo byte, A=hi byte of a 16-bit value -> FAC1
+; note: for u8, A must be $00; the calling stub in float.s may need adjustment
+BASIC_u8_to_FAC     = $793c     ; y: value (GIVAYF; A must be $00 for correct u8 conversion)
+BASIC_s8_to_FAC     = $8c68     ; a: value (SNGFLT = SGN+3, same structure as C64/VIC-20)
+BASIC_u16_to_FAC    = $8c75     ; FLOATC: store hi->$64, lo->$65 before call, ldx#$90 sec
+BASIC_s16_to_FAC    = $793c     ; Y=lo/A=hi value (GIVAYF)
 
-BASIC_FAC_to_u16    = $bc9b     ; in:FAC out: y/a:lo/hi value
+BASIC_FAC_to_u16    = $84b4     ; in:FAC out: signed int in $66(hi)/$67(lo) (AYINT)
 
-BASIC_string_to_FAC = $b7b5     ; in: $22/$23 ptr to str,a=strlen out: FAC value
-BASIC_FAC_to_string = $bddd     ; in: FAC value   out: str at $0100 a/y ptr to str
+; note: C128 VAL_1 expects string pointer in $24/$25, not $22/$23 as on C64/VIC-20
+BASIC_string_to_FAC = $8052     ; in: $24/$25 ptr to str, a=strlen out: FAC (VAL_1)
+BASIC_FAC_to_string = $8e42     ; in: FAC value   out: str at $0100 a/y ptr to str (FOUT)
 
-BASIC_LoadARG       = $ba8c     ; a/y:lo/hi ptr to 5-byte float
-BASIC_LoadFAC       = $bba2     ; a/y:lo/hi ptr to 5-byte float
+BASIC_LoadARG       = $8a89     ; a/y:lo/hi ptr to 5-byte float, loads FAC2 (ROMUPK, current bank)
+BASIC_LoadFAC       = $8bd4     ; a/y:lo/hi ptr to 5-byte float, loads FAC1 (MOVFM, current bank)
 
-BASIC_FAC_testsgn   = $bc2b     ; in: FAC(x1) out: a=0 (x1=0) a=1 (x1>0) a=255 (x1<0)
-BASIC_FAC_cmp       = $bc5b     ; in: FAC(x1) a/y ptr lo/hi to x2 out: a=0 (x1=x2) a=1 (x1>x2) a=255 (x1<x2)
+BASIC_FAC_testsgn   = $8c57     ; in: FAC(x1) out: a=0 (x1=0) a=1 (x1>0) a=255 (x1<0) (SIGN)
+BASIC_FAC_cmp       = $8c87     ; in: FAC(x1) a/y ptr lo/hi to x2 out: a=0 (x1=x2) a=1 (x1>x2) a=255 (x1<x2) (FCOMP)
 
-BASIC_FAC_Poly2     = $e043     ; in: FAC x  a/y ptr to poly (1byte grade,5bytes per coefficient)
-BASIC_FAC_Poly1     = $e059     ; in: FAC x  a/y ptr to poly (1byte grade,5bytes per coefficient)
-
+BASIC_FAC_Poly2     = $909c     ; in: FAC x  a/y ptr to poly (1byte grade,5bytes per coeff) EXP series
+BASIC_FAC_Poly1     = $9086     ; in: FAC x  a/y ptr to poly (1byte grade,5bytes per coeff) LOG/SIN/COS/TAN/ATN series

--- a/float.inc
+++ b/float.inc
@@ -3,6 +3,8 @@
             .include "float-vic20.inc"
         .elseif .def (__C64__)
             .include "float-c64.inc"
+        .elseif .def (__C128__)
+            .include "float-c128.inc"
         .else
             .error "Unsupported target"
         .endif

--- a/float.s
+++ b/float.s
@@ -26,20 +26,32 @@ __basicoff:
         rts
 .endif
 
+.if .defined(__C128__)
+__basicon:
+        ldx #$00        ; use X, not A — callers may pass arguments in A
+        stx $FF00       ; MMU Configuration Register: BASIC ROM + Kernal ROM visible
+        rts
+
+__basicoff:
+        ldx #$0E        ; MMU_CFG_CC65: Kernal ROM only, BASIC ROM area = RAM
+        stx $FF00       ; MMU Configuration Register
+        rts
+.endif
+
 .macro __enable_basic_if_needed
-  .if .defined(__C64__)
+  .if .defined(__C64__) .or .defined(__C128__)
         jsr __basicon
   .endif
 .endmacro
 
 .macro __disable_basic_if_needed
-  .if .defined(__C64__)
+  .if .defined(__C64__) .or .defined(__C128__)
         jsr __basicoff
   .endif
 .endmacro
 
 .macro __return_with_cleanup
-  .if .defined(__C64__)
+  .if .defined(__C64__) .or .defined(__C128__)
         jmp __basicoff
   .else
         rts
@@ -72,6 +84,9 @@ ___float_u8_to_fac:
         ;y: low
 __float_u8_to_fac:
         __enable_basic_if_needed
+.if .defined(__C128__)
+        lda #0          ; C128 GIVAYF takes Y=lo/A=hi; zero A for unsigned byte
+.endif
         jsr BASIC_u8_to_FAC
         __return_with_cleanup
         
@@ -123,13 +138,18 @@ __float_fac_to_str:
         jsr BASIC_FAC_to_string
         __return_with_cleanup
 
+; NOTE: C128 does NOT define ___float_str_to_fac / __strtof here.
+; VAL_1 ($8052) reads from bank 1 RAM and must not be called from bank 0.
+; _strtof for C128 is implemented in floatc.c instead.
+.if .not .defined(__C128__)
 ___float_str_to_fac:
 ;        jsr popax
 __float_str_to_fac:
-        sta $22
+        sta $22         ; C64/VIC-20 string_to_FAC expects pointer in $22/$23
         stx $23
         ldy #$00
-@l:     lda ($22),y
+@l:
+        lda ($22),y
         beq @s
         iny
         bne @l
@@ -137,6 +157,7 @@ __float_str_to_fac:
         __enable_basic_if_needed
         jsr BASIC_string_to_FAC
         __return_with_cleanup
+.endif
 
 ;---------------------------------------------------------------------------------------------
 
@@ -507,14 +528,17 @@ __float_strbuf_to_string:
         ldx ptr1+1
         rts
 
+; _strtof: C128 version lives in floatc.c (VAL_1 requires bank 1 strings)
+.if .not .defined(__C128__)
         .export __strtof
-        
-; convert a string to a float        
-; float __fastcall__ _strtof(char *d);        
-;-> unsigned long __fastcall__ _strtof(char *d);        
+
+; convert a string to a float
+; float __fastcall__ _strtof(char *d);
+;-> unsigned long __fastcall__ _strtof(char *d);
 __strtof:
         jsr ___float_str_to_fac
         jmp ___float_fac_to_float
+.endif
 
         .export __ctof
 
@@ -598,13 +622,7 @@ __fround:  __ffunc1 BASIC_FAC_Round
 ;---------------------------------------------------------------------------------------------
         
 __float_ret2:
-
-        ;jsr __basicoff
-.if .defined(__C64__)
-        ldx #$36
-        stx $01
-        cli
-.endif
+        __disable_basic_if_needed
         jmp ___float_fac_to_float    ; also pops pointer to float
 
 .macro __ffunc2a addr
@@ -638,14 +656,9 @@ __fand:   __ffunc2b BASIC_ARG_FAC_And
 __for:    __ffunc2b BASIC_ARG_FAC_Or
         
 __float_ret3:
-        ;jsr __basicoff
-.if .defined(__C64__)
-        ldx #$36
-        stx $01
-        cli
-.endif
+        __disable_basic_if_needed
         ldx #0
-        rts  
+        rts
         
         .bss
         

--- a/float.s
+++ b/float.s
@@ -35,6 +35,7 @@ __basicon:
 __basicoff:
         ldx #$0E        ; MMU_CFG_CC65: Kernal ROM only, BASIC ROM area = RAM
         stx $FF00       ; MMU Configuration Register
+        cli
         rts
 .endif
 
@@ -89,27 +90,27 @@ __float_u8_to_fac:
 .endif
         jsr BASIC_u8_to_FAC
         __return_with_cleanup
-        
+
 ; get C-parameter (signed int), convert to FAC
 ___float_s16_to_fac:
         ;a: low x: high
         tay
         txa
         ;y: low a: high
-        
+
 ; convert signed int (YA) to FAC
 __float_s16_to_fac:
         __enable_basic_if_needed           ; enable BASIC (trashes X)
         jsr BASIC_s16_to_FAC
         __return_with_cleanup
-       
-; get C-parameter (unsigned short), convert to FAC          
+
+; get C-parameter (unsigned short), convert to FAC
 ___float_u16_to_fac:
         ;a: low x: high
         tay
         txa
         ;y: low a: high
-        
+
 __float_u16_to_fac:
         sta FAC_MANTISSA0
         sty FAC_MANTISSA1
@@ -127,7 +128,7 @@ __float_fac_to_u16:
         ldx FAC_MANTISSA2
         lda FAC_MANTISSA3
         rts
-        
+
 ;---------------------------------------------------------------------------------------------
 ; converter float to string and back
 ;---------------------------------------------------------------------------------------------
@@ -167,9 +168,9 @@ ___float_float_to_fac:
         sta FAC_MANTISSA1   ; 3
         stx FAC_MANTISSA0   ; 2
         ldy sreg            ; 1
-        sty FAC_EXPONENT    
+        sty FAC_EXPONENT
         ldy sreg+1          ; 0
-        sty FAC_SIGN        
+        sty FAC_SIGN
 
         ldx #$00
         stx FAC_MANTISSA2
@@ -181,7 +182,7 @@ ___float_float_to_fac:
         stx FAC_MANTISSA1   ; 2
         lda sreg            ; 1
         ora #$80
-        sta FAC_MANTISSA0   
+        sta FAC_MANTISSA0
 
         ; bit7=0 sign=0
         ; bit7=1 sign=$ff
@@ -193,7 +194,7 @@ ___float_float_to_fac:
         stx FAC_SIGN
 
         ldy sreg+1          ; 0
-        sty FAC_EXPONENT    
+        sty FAC_EXPONENT
 
         ldx #$00
         stx FAC_MANTISSA3
@@ -230,9 +231,9 @@ ___float_float_to_fac:
         stx FAC_ROUNDING
 .endif
         rts
-        
-; load BASIC float into FAC        
-; in: pointer (a/x) to BASIC float (not packed)        
+
+; load BASIC float into FAC
+; in: pointer (a/x) to BASIC float (not packed)
 __float_float_to_fac:   ; only used in ATAN2?
         sta ptr1
         stx ptr1+1
@@ -268,7 +269,7 @@ ___float_float_to_fac_arg:
 ___float_float_to_arg:
         ldy #$03
         jsr ldeaxysp
-        
+
 .if BINARYFORMAT = BINARYFORMAT_CBM_UNPACKED
         sta ARG_MANTISSA1   ; 3
         stx ARG_MANTISSA0   ; 2
@@ -290,8 +291,8 @@ ___float_float_to_arg:
         stx ARG_MANTISSA1   ; 2
         lda sreg            ; 1
         ora #$80
-        sta ARG_MANTISSA0   
-        
+        sta ARG_MANTISSA0
+
         ; bit7=0 sign=0
         ; bit7=1 sign=$ff
         ldx #0
@@ -300,13 +301,13 @@ ___float_float_to_arg:
         dex
 @pos:
         stx ARG_SIGN
-        
+
         ldy sreg+1          ; 0
-        sty ARG_EXPONENT    
+        sty ARG_EXPONENT
 
         ldx #$00
         stx ARG_MANTISSA3
-        
+
         lda ARG_SIGN
         eor FAC_SIGN
         sta FAC_SIGN_COMPARE ; sign compare
@@ -349,7 +350,7 @@ ___float_float_to_arg:
         jmp incsp4
 
 ; load BASIC float into ARG
-; in: pointer (a/x) to BASIC float (not packed)        
+; in: pointer (a/x) to BASIC float (not packed)
 __float_float_to_arg:   ; only used in ATAN2?
         sta ptr1
         stx ptr1+1
@@ -375,7 +376,7 @@ __float_float_to_arg:   ; only used in ATAN2?
         eor FAC_SIGN
         sta FAC_SIGN_COMPARE
         rts
-        
+
 ; return to C, float as unsigned long
 ___float_fac_to_float:
 .if BINARYFORMAT = BINARYFORMAT_CBM_UNPACKED
@@ -385,11 +386,11 @@ ___float_fac_to_float:
         sta sreg            ; 1
         ldx FAC_MANTISSA0   ; 2
         lda FAC_MANTISSA1   ; 3
-.endif        
+.endif
 .if BINARYFORMAT = BINARYFORMAT_CBM_PACKED
         lda FAC_EXPONENT
         sta sreg+1          ; 0
-        
+
         ; use the MSB of the mantissa for the sign
         lda FAC_SIGN        ; either $ff or $00
         ora #$7f            ; ->     $ff or $7f
@@ -398,7 +399,7 @@ ___float_fac_to_float:
 
         ldx FAC_MANTISSA1   ; 2
         lda FAC_MANTISSA2   ; 3
-.endif        
+.endif
 .if BINARYFORMAT = BINARYFORMAT_IEEE754
         ; return float in a/x/sreg/sreg+1
         lda FAC_EXPONENT
@@ -419,10 +420,10 @@ ___float_fac_to_float:
         ldx FAC_MANTISSA1   ; 2
         lda FAC_MANTISSA2   ; 3 lsb
 
-.endif        
-        rts        
+.endif
+        rts
 
-;; store float in memory        
+;; store float in memory
 ;; in: dest. pointer (a/x), float in FAC
 ;__float_fac_to_float:   ; UNUSED
 ;        sta ptr1
@@ -447,8 +448,8 @@ ___float_fac_to_float:
 ;        sta (ptr1),y
 ;        rts
 
-;; store packed float in memory        
-;; in: dest. pointer (a/x), float in FAC        
+;; store packed float in memory
+;; in: dest. pointer (a/x), float in FAC
 ;__float_fac_to_float_packed:    ; UNUSED
 ;        sta ptr1
 ;        stx ptr1+1
@@ -471,8 +472,8 @@ ___float_fac_to_float:
 ;        lda FAC_EXPONENT
 ;        sta (ptr1),y
 ;        rts
-        
-;; store packed float in memory        
+
+;; store packed float in memory
 ;; in: dest. pointer (a/x), float in ARG
 __float_arg_to_float_packed:
         sta ptr1
@@ -496,7 +497,7 @@ __float_arg_to_float_packed:
         lda ARG_EXPONENT
         sta (ptr1),y
         rts
-        
+
 ;---------------------------------------------------------------------------------------------
 
         .export __ftostr
@@ -550,7 +551,7 @@ __strtof:
         jmp ___float_fac_to_float
 
         .export __utof
-        
+
 ; convert unsigned char to float
 ; float __fastcall__ _utof(unsigned char v);
 ;-> unsigned long __fastcall__ _utof(unsigned char v);
@@ -559,7 +560,7 @@ __strtof:
         jmp ___float_fac_to_float
 
         .export __stof
-        
+
 ; convert short to float
 ; float __fastcall__ _stof(unsigned short v);
 ;-> unsigned long __fastcall__ _stof(unsigned short v);
@@ -578,7 +579,7 @@ __strtof:
         jmp ___float_fac_to_float
 
         .export __ftoi
-        
+
 ; convert float to integer
 ; int __fastcall__ _ftoi(float f);
 ;-> int __fastcall__ _ftoi(unsigned long f);
@@ -616,11 +617,11 @@ __fsqr:    __ffunc1 BASIC_FAC_Sqr
 __ftan:    __ffunc1 BASIC_FAC_Tan
 __fnot:    __ffunc1 BASIC_FAC_Not
 __fround:  __ffunc1 BASIC_FAC_Round
-        
+
 ;---------------------------------------------------------------------------------------------
 ; these functions take two args (in FAC and ARG) and return result (in FAC)
 ;---------------------------------------------------------------------------------------------
-        
+
 __float_ret2:
         __disable_basic_if_needed
         jmp ___float_fac_to_float    ; also pops pointer to float
@@ -639,11 +640,11 @@ __float_ret2:
         jsr addr
         jmp __float_ret2
 .endmacro
-        
+
         .export __fadd, __fsub, __fmul, __fdiv, __fpow
 
-; float __fastcall__ _fadd(float f, float a);        
-;-> unsigned long __fastcall__ _fadd(unsigned long f, unsigned long a);        
+; float __fastcall__ _fadd(float f, float a);
+;-> unsigned long __fastcall__ _fadd(unsigned long f, unsigned long a);
 __fadd:   __ffunc2a BASIC_ARG_FAC_Add
 __fsub:   __ffunc2a BASIC_ARG_FAC_Sub
 __fmul:   __ffunc2a BASIC_ARG_FAC_Mul
@@ -654,21 +655,21 @@ __fpow:   __ffunc2a BASIC_ARG_FAC_Pow
 
 __fand:   __ffunc2b BASIC_ARG_FAC_And
 __for:    __ffunc2b BASIC_ARG_FAC_Or
-        
+
 __float_ret3:
         __disable_basic_if_needed
         ldx #0
         rts
-        
+
         .bss
-        
+
 tempfloat:
         .res 5
 
         .SEGMENT "LOWCODE"
-        
+
         .export __fcmp
-        
+
 __fcmp:
         jsr ___float_float_to_fac_arg
         lda #<tempfloat
@@ -684,7 +685,7 @@ ___float_cmp_fac_arg:
         jmp __float_ret3
 
         .export __ftestsgn
-        
+
 __ftestsgn:
         jsr ___float_float_to_fac
 ;___float_testsgn_fac:
@@ -692,7 +693,7 @@ __ftestsgn:
         ; in: FAC(x1)
         jsr BASIC_FAC_testsgn
         jmp __float_ret3
-        
+
 ___float_testsgn_fac:
         lda FAC_EXPONENT
         beq @s
@@ -742,9 +743,9 @@ __fpoly2:
         __enable_basic_if_needed
         jsr BASIC_FAC_Poly1
         jmp __float_ret2
-        
+
 ;---------------------------------------------------------------------------------------------
-        
+
 __float_atn_fac:
         __enable_basic_if_needed
         jsr BASIC_FAC_Atn
@@ -759,7 +760,7 @@ __float_add_fac_arg:
         lda FAC_EXPONENT
         jsr BASIC_ARG_FAC_Add
         __return_with_cleanup
-        
+
 __float_swap_fac_arg:           ; only used in ATAN2
         lda   FAC_EXPONENT
         ldx   ARG_EXPONENT
@@ -786,7 +787,7 @@ __float_swap_fac_arg:           ; only used in ATAN2
         stx   FAC_SIGN
         sta   ARG_SIGN
         rts
-        
+
         .export __fneg
 __fneg:
         jsr ___float_float_to_fac
@@ -798,8 +799,8 @@ __fneg:
         sta FAC_SIGN
 @sk:
         jmp ___float_fac_to_float
-        
-        
+
+
 __f_pi2:  .byte $81,$80+$49,$0f,$da,$a1,$00
 __f_pi:   .byte $82,$80+$49,$0f,$da,$a1,$00
 __f_1pi2: .byte $83,$80+$16,$cb,$e3,$f9,$00
@@ -855,4 +856,4 @@ __fatan2:
                         ldx #>__f_1pi2
                         jsr __float_float_to_fac
                         jmp __float_ret2
-        
+

--- a/floatc.c
+++ b/floatc.c
@@ -17,6 +17,27 @@ double my_floor_2(double num) {
 }
 #endif
 
+/* C128: VAL_1 ($8052) reads strings from bank 1 and cannot be called from bank 0.
+ * Provide a simple decimal-integer parser using the existing float operations.
+ * TODO: add decimal-point and exponent support if needed. */
+#if defined(__CC65__) && defined(__C128__)
+float __fastcall__ _strtof(char *s)
+{
+    int n = 0;
+    char neg = 0;
+
+    if (*s == '-') { neg = 1; s++; }
+    else if (*s == '+') { s++; }
+
+    while (*s >= '0' && *s <= '9') {
+        n = n * 10 + (*s - '0');
+        s++;
+    }
+    if (neg) return fneg(itof(n));
+    return itof(n);
+}
+#endif
+
 /* FIXME: this is really too simple */
 float ffloor(float x)
 {

--- a/floatc.c
+++ b/floatc.c
@@ -20,7 +20,7 @@ double my_floor_2(double num) {
 /* C128: VAL_1 ($8052) reads strings from bank 1 and cannot be called from bank 0.
  * Provide a simple decimal-integer parser using the existing float operations.
  * TODO: add decimal-point and exponent support if needed. */
-#if defined(__CC65__) && defined(__C128__)
+#if defined(__C128__)
 float __fastcall__ _strtof(char *s)
 {
     int n = 0;
@@ -43,7 +43,7 @@ float ffloor(float x)
 {
     signed long n;
     float d;
-    
+
     n = ftol(x);
     d = ltof(n);
 
@@ -51,17 +51,17 @@ float ffloor(float x)
         return d;
     }
     return fsub(d, 1);
-} 
+}
 
 // convert float into a string. this is surprisingly complex, so we just use
 // the kernal function, and then fix up the result
 
-char *ftoa(char *buf, float n) 
-{ 
+char *ftoa(char *buf, float n)
+{
     char i, ii, epos = 0, ex;
     char tempbuf[0x20];
     _ftostr(tempbuf, n);
-    
+
     // find position of the 'e'
     i=0;while(tempbuf[i]) {
         if (tempbuf[i] == 69) { /* 'e' */
@@ -70,14 +70,14 @@ char *ftoa(char *buf, float n)
         }
         i++;
     }
-    
+
     if (epos == 0) {
         i = ii = 0;
         // no exponent, we can return the number as is
         if (tempbuf[i] == '-') {
             buf[ii] = tempbuf[i];
             i++;ii++;
-        } 
+        }
 //         else {
 //             buf[ii] = ' ';
 //             ii++;
@@ -100,12 +100,12 @@ char *ftoa(char *buf, float n)
         buf[ii] = 0;
     } else {
         // we have an exponent, get rid of it
-        
+
         i = ii = 0;
         if (tempbuf[i] == '-') {
             buf[ii] = tempbuf[i];
             i++;ii++;
-        } 
+        }
 //         else {
 //             buf[ii] = ' ';
 //             ii++;
@@ -114,18 +114,18 @@ char *ftoa(char *buf, float n)
         if (tempbuf[i] == ' ') {
             i++;
         }
-        
+
         ex = ((tempbuf[epos+2] - '0') * 10) + (tempbuf[epos+3] - '0');
 
         if (tempbuf[epos+1] == '+') {
             // positive exponent, move decimal point to right, add zeros to the right
-            
+
             // first copy until we see either the decimal point, or the 'e'
             while (tempbuf[i] && tempbuf[i] != '.' && tempbuf[i] != 69) {
                 buf[ii] = tempbuf[i];
                 i++;ii++;
             }
-            
+
             // 'e' found, add as many zeros as in the exponent
             if (tempbuf[i] == 69) {
                 while(ex) {
@@ -150,15 +150,15 @@ char *ftoa(char *buf, float n)
                     ex--;
                 }
             }
-            
+
         } else {
             // negative exponent, move decimal point to left, add zeros to left
-            
+
             buf[ii] = '0'; ii++;
             buf[ii] = '.'; ii++;
 
             ex--;
-            
+
             // add zeros
             while(ex) {
                 buf[ii] = '0';
@@ -173,10 +173,10 @@ char *ftoa(char *buf, float n)
                 buf[ii] = tempbuf[i];
                 i++;ii++;
             }
-            
+
         }
         buf[ii] = 0;
     }
-    
-    return buf; 
+
+    return buf;
 }

--- a/makefile
+++ b/makefile
@@ -25,7 +25,6 @@ floattest.prg: runtime.lib math.h float.h floattest.c
 #	cl65 $(CC65_FLAGS) -Osir floattest.c runtime.lib -o floattest.prg
 	cl65 $(CC65_FLAGS) floattest.c runtime.lib -o floattest.prg
 #	cc65 $(CC65_FLAGS) floattest.c -o floattest.s
-
 floattest: floattest.c math.h float.h
 	gcc -O2 -W -Wall -Wextra -o floattest -lm floattest.c
 

--- a/makefile
+++ b/makefile
@@ -13,6 +13,10 @@ ifeq ($(SYS),vic20)
   CC65_FLAGS = -C vic20-32k.cfg
 endif
 
+ifeq ($(SYS),c128)
+  VICE_CMD = x128
+endif
+
 all: runtime.lib floattest.prg floattest
 
 runtime.lib: float.s floatc.c float.inc
@@ -22,9 +26,10 @@ runtime.lib: float.s floatc.c float.inc
 	ar65 a runtime.lib float.o floatc.o
 
 floattest.prg: runtime.lib math.h float.h floattest.c
-#	cl65 $(CC65_FLAGS) -Osir floattest.c runtime.lib -o floattest.prg
-	cl65 $(CC65_FLAGS) floattest.c runtime.lib -o floattest.prg
-#	cc65 $(CC65_FLAGS) floattest.c -o floattest.s
+#	cl65 -t $(SYS) $(CC65_FLAGS) -Osir floattest.c runtime.lib -o floattest.prg
+	cl65 -t $(SYS) $(CC65_FLAGS) floattest.c runtime.lib -o floattest.prg
+#	cc65 -t $(SYS) $(CC65_FLAGS) floattest.c -o floattest.s
+
 floattest: floattest.c math.h float.h
 	gcc -O2 -W -Wall -Wextra -o floattest -lm floattest.c
 


### PR DESCRIPTION
Implement https://github.com/mrdudz/cc65-floatlib/issues/6

Screenshots of `floattest`s after the change:

<img width="832" height="782" alt="c64" src="https://github.com/user-attachments/assets/276d9732-d760-4795-84f5-77a00019493b" />
<img width="832" height="782" alt="c128" src="https://github.com/user-attachments/assets/915a0395-f813-471c-90b5-90d55a4f5624" />
<img width="859" height="806" alt="vic20" src="https://github.com/user-attachments/assets/82b09547-e35b-461a-b726-696e57ed4c52" />
